### PR TITLE
Introduce Fly.io scaling

### DIFF
--- a/.github/workflows/downsize-insurance.yml
+++ b/.github/workflows/downsize-insurance.yml
@@ -1,0 +1,19 @@
+name: Downsize Fly.io VM
+# `sync.yml` needs to scale Fly.io VM to an higher-cost tier to get its job done.
+# However, if sync.yml fails to execute to the end it poses a risk of 
+# large Fly.io bills. `downsize-insurance.yml` is intended to run after the sync
+# job finishes as a failsafe.
+
+on:
+  schedule:
+  - cron: '30 0 * * *'
+
+jobs:
+  downsize:
+    name: Downsize Fly.io VM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Scale Fly VM down
+        run: flyctl scale vm shared-cpu-1x --memory=2048
+        env:
+          FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -45,7 +45,7 @@ jobs:
       env:
         SEAFOWL_PASSWORD: ${{ secrets.SEAFOWL_PASSWORD }}
       run: |
-        ./pants run src/s2sf:s2sf -- vacuum https://seafowl-socrata.fly.dev
+        ./pants run src/s2sf:s2sf -- build https://seafowl-socrata.fly.dev || (echo "retrying"; sleep 10; ./pants run src/s2sf:s2sf -- build https://seafowl-socrata.fly.dev)
     - name: Scale Fly VM down
       run: flyctl scale vm shared-cpu-1x --memory=2048
       env:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup flyctl
       uses: superfly/flyctl-actions/setup-flyctl@master
     - name: Scale Fly VM up and block until finished
-      run: flyctl scale vm dedicated-cpu-2x --memory=16384; sleep 10; flyctl monitor
+      run: flyctl scale vm dedicated-cpu-4x--memory=32768; sleep 10; flyctl monitor
       env:
         FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}
     - name: Run the sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -25,8 +25,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Setup flyctl
       uses: superfly/flyctl-actions/setup-flyctl@master
-    - name: Scale Fly VM up
-      run: flyctl scale vm dedicated-cpu-2x --memory=16384
+    - name: Scale Fly VM up and block until finished
+      run: flyctl scale vm dedicated-cpu-2x --memory=16384; sleep 3; flyctl monitor
       env:
         FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}
     - name: Run the sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         ./pants run src/s2sf:s2sf -- build https://seafowl-socrata.fly.dev || (echo "retrying"; sleep 10; ./pants run src/s2sf:s2sf -- build https://seafowl-socrata.fly.dev)
     - name: Scale Fly VM down
-      if: always
+      if: always()
       run: flyctl scale vm shared-cpu-1x --memory=2048
       env:
         FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup flyctl
       uses: superfly/flyctl-actions/setup-flyctl@master
     - name: Scale Fly VM up and block until finished
-      run: flyctl scale vm dedicated-cpu-2x --memory=16384; sleep 3; flyctl monitor
+      run: flyctl scale vm dedicated-cpu-2x --memory=16384; sleep 5; flyctl monitor
       env:
         FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}
     - name: Run the sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup flyctl
       uses: superfly/flyctl-actions/setup-flyctl@master
     - name: Scale Fly VM up and block until finished
-      run: flyctl scale vm dedicated-cpu-2x --memory=16384; sleep 5; flyctl monitor
+      run: flyctl scale vm dedicated-cpu-2x --memory=16384; sleep 10; flyctl monitor
       env:
         FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}
     - name: Run the sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,6 +23,10 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Setup flyctl
+      uses: superfly/flyctl-actions/setup-flyctl@master
+    - name: Scale Fly VM up
+      run: flyctl scale vm dedicated-cpu-2x --memory=16384
     - name: Run the sync
       env:
         SEAFOWL_PASSWORD: ${{ secrets.SEAFOWL_PASSWORD }}
@@ -38,3 +42,5 @@ jobs:
         SEAFOWL_PASSWORD: ${{ secrets.SEAFOWL_PASSWORD }}
       run: |
         ./pants run src/s2sf:s2sf -- vacuum https://seafowl-socrata.fly.dev
+    - name: Scale Fly VM down
+      run: flyctl scale vm shared-cpu-1x --memory=2048

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,7 +1,9 @@
 name: Sync Socrata to Seafowl
 
-# TODO add cronjob
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  # schedule:
+  # - cron: "10 0 * * *"
 
 jobs:
   sync:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -47,6 +47,7 @@ jobs:
       run: |
         ./pants run src/s2sf:s2sf -- build https://seafowl-socrata.fly.dev || (echo "retrying"; sleep 10; ./pants run src/s2sf:s2sf -- build https://seafowl-socrata.fly.dev)
     - name: Scale Fly VM down
+      if: always
       run: flyctl scale vm shared-cpu-1x --memory=2048
       env:
         FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup flyctl
       uses: superfly/flyctl-actions/setup-flyctl@master
     - name: Scale Fly VM up and block until finished
-      run: flyctl scale vm dedicated-cpu-4x--memory=32768; sleep 10; flyctl monitor
+      run: flyctl scale vm dedicated-cpu-4x --memory=32768; sleep 10; flyctl monitor
       env:
         FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}
     - name: Run the sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Setup flyctl
       uses: superfly/flyctl-actions/setup-flyctl@master
     - name: Scale Fly VM up and block until finished
-      run: flyctl scale vm dedicated-cpu-4x --memory=32768; sleep 10; flyctl monitor
+      run: flyctl scale vm dedicated-cpu-4x --memory=32768; sleep 10; flyctl monitor; sleep 10
       env:
         FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}
     - name: Run the sync

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -27,6 +27,8 @@ jobs:
       uses: superfly/flyctl-actions/setup-flyctl@master
     - name: Scale Fly VM up
       run: flyctl scale vm dedicated-cpu-2x --memory=16384
+      env:
+        FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}
     - name: Run the sync
       env:
         SEAFOWL_PASSWORD: ${{ secrets.SEAFOWL_PASSWORD }}
@@ -44,3 +46,5 @@ jobs:
         ./pants run src/s2sf:s2sf -- vacuum https://seafowl-socrata.fly.dev
     - name: Scale Fly VM down
       run: flyctl scale vm shared-cpu-1x --memory=2048
+      env:
+        FLY_ACCESS_TOKEN: ${{ secrets.FLY_ACCESS_TOKEN }}

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -2,8 +2,8 @@ name: Sync Socrata to Seafowl
 
 on:
   workflow_dispatch:
-  # schedule:
-  # - cron: "10 0 * * *"
+  schedule:
+  - cron: "10 0 * * *"
 
 jobs:
   sync:


### PR DESCRIPTION
### Goal
To regularly populate the Seafowl instance powering [SocFeed](https://socfeed.vercel.app/) in as automated of a way as possible.

### Non goal
Because the load job needs more memory than Seafowl does to serve normal HTTP traffic, we seek to avoid burning $ by scaling the VM up (and down) as needed.

### Method
GHA runs the [official](https://github.com/superfly/flyctl-actions) flyctl action, we scale the Fly.io VM up, runs the sync job, then scale it back down.